### PR TITLE
Fix for undefined options.success key

### DIFF
--- a/jquery-ajax-localstorage-cache.js
+++ b/jquery-ajax-localstorage-cache.js
@@ -40,7 +40,8 @@ $.ajaxPrefilter( function( options, originalOptions, jqXHR ) {
     //In the cache? So get it, apply success callback & abort the XHR request
     // parse back to JSON if we can.
     if ( options.dataType.indexOf( 'json' ) === 0 ) value = JSON.parse( value );
-    options.success( value );
+    options['success'] = value;
+    
     // Abort is broken on JQ 1.5 :(
     jqXHR.abort();
   } else {


### PR DESCRIPTION
Uncaught TypeError: undefined is not a function since options.success didn't exist.